### PR TITLE
Fixed a bug caused by upgrading to scikit-learn 0.20.2

### DIFF
--- a/PREDICT/processing/fitandscore.py
+++ b/PREDICT/processing/fitandscore.py
@@ -537,6 +537,14 @@ def fit_and_score(estimator, X, y, scorer,
                          return_n_test_samples,
                          return_times, error_score)
 
+    # Remove 'estimator object', it's the causes of a bug.
+    # Somewhere between scikit-learn 0.18.2 and 0.20.2
+    # the estimator object return value was added
+    # removing this element fixes a bug that occurs later
+    # in SearchCV.py, where an array without estimator
+    # object is expected.
+    del ret[-1]
+
     # Paste original parameters in performance
     ret.append(para)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ python-dateutil>=2.5.3
 pytz>=2016.7
 rdflib>=4.2.1
 scikit-image>=0.12.3
-scikit-learn>=0.18.2
+scikit-learn==0.20.2
 scipy>=0.18.1
 SimpleITK>=0.9.1
 simplejson>=3.10.0


### PR DESCRIPTION
Somewhere between scikit-learn 0.18.2 and 0.20.2 the estimator object return value was added to _fit_and_score. Removing this element fixes a bug that occurs later in SearchCV.py, where an array without estimator object is expected.

I've set the scikit-learn version in requirements.txt to 0.20.2. Since _fit_and_score is a private function that should not be called outside scikit-learn there is no guarantee that this function won't change. Hence the best solution, in my opinion, is to affix the version to a version that we know works. This does mean that we have to update the version once in a while and test if it still works to keep up-to-date. This could be done as part of the release process maybe?